### PR TITLE
Solve DID example resolves #2

### DIFF
--- a/R/DID.R
+++ b/R/DID.R
@@ -11,7 +11,7 @@ DID <- function( M, mask ){
   control_rows <- setdiff(1:nrow(M), treated_rows)
   num_treated <- length(treated_rows)
   num_control <- length(control_rows)
-  M_control_rows <- M[control_rows,]
+  M_control_rows <- M[control_rows,, drop=FALSE]
   M_pred <- M
   for (l in 1:num_treated){
     tr_row_pred <- treated_rows[l]


### PR DESCRIPTION
The problem in the example was due to the infamous problem of R dropping dimension from matrix to scalar. This fix jsut adds `drop=FALSE`, so now the example runs. 

``` r
library(MCPanel)
DID(matrix(c(1,2,3,4),2,2), matrix(c(1,1,1,0),2,2))
#>      [,1] [,2]
#> [1,]    1    3
#> [2,]    2    4
```

<sup>Created on 2021-08-17 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>